### PR TITLE
fix: always save_today_stories in category run, even on cache hit

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -1859,6 +1859,8 @@ def main():
         world_topics = memory.get("world_topics_cache", {"today": [], "week": [], "month": []}) if RUN_CATEGORY != "world_topics" else world_topics
         yesterday_data = {cat: get_previous_stories(memory, cat) for cat in ["breaking", "australia", "archaeology", "football"]}
         developing_situations = process_developing_situations(pinned, [], [])
+        if RUN_CATEGORY in ("breaking", "australia", "archaeology", "football"):
+            memory = save_today_stories(memory, RUN_CATEGORY, result)
         save_memory(memory)
         Path("dist").mkdir(exist_ok=True)
         with open("dist/index.html", "w", encoding="utf-8") as f:


### PR DESCRIPTION
When category_has_changed() returned False, get_cached_category() was used for display but save_today_stories() was never called, so today's date key in memory['stories'] was never populated. Subsequent calls to get_previous_stories() would then skip today entirely and return stale data from an earlier date. Fix adds a save_today_stories() call before save_memory() for all four refreshable categories regardless of whether the stories were freshly processed or pulled from cache.