### PR TITLE
Fix modal onclick corruption and developing situations object repr

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Daily Briefing — Project Status
 
 ## Last Shipped
-v0.5 Bug fixes pass 5 — Breaking news heads-of-state carve-out, Australia prompt philosophy rewrite, AI refusal retry fallback in get_ai_summary()
+Fixed modal onclick corruption via data-attrs; fixed developing situations .update() assignment bug
 
 ## 🔄 In Progress
 Nothing currently in progress.

--- a/page/template.html
+++ b/page/template.html
@@ -23,7 +23,7 @@
 {# Tracking suggestions for star popup #}
 {% set suggested = story.headline[:60].rstrip('.,') %}
 {% set suggestions = story.tracking_suggestions if story.tracking_suggestions else [suggested] %}
-<div class="story" onclick="openModal({{ headline_js }},{{ summary_js }},{{ articles_js }},{{ image_js }})" style="border-radius:10px;background:{{ card_bg }};border:{{ card_border }};margin-bottom:8px;opacity:{{ opacity }};cursor:pointer;transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(255,255,255,0.15)'" onmouseout="this.style.borderColor=''">
+<div class="story" data-headline="{{ story.headline|e }}" data-summary="{{ story.summary|default('')|replace('\n',' ')|e }}" data-articles="{{ arts|tojson|e }}" data-image="{{ image|e }}" style="border-radius:10px;background:{{ card_bg }};border:{{ card_border }};margin-bottom:8px;opacity:{{ opacity }};cursor:pointer;transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(255,255,255,0.15)'" onmouseout="this.style.borderColor=''">
   <div style="display:flex;align-items:flex-start;gap:14px;padding:16px 18px;border-radius:10px;">
     <span style="font-size:11px;color:#2a2a28;min-width:20px;margin-top:3px;flex-shrink:0;">{{ num }}</span>
     <div style="flex:1;min-width:0;">
@@ -44,13 +44,13 @@
 {% if source %}{% set ns.parts = ns.parts + [source] %}{% endif %}
 {% set meta = ns.parts|join(' · ') %}
 {% if arts|length > 1 %}{% set meta = meta ~ ' · ' ~ arts|length ~ ' sources' %}{% endif %}
-<div onclick="openModal({{ headline_js }},{{ summary_js }},{{ articles_js }},{{ image_js }})" style="background:{{ card_bg }};border:1px solid {{ card_border }};border-radius:10px;padding:16px 18px;cursor:pointer;transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(255,255,255,0.15)'" onmouseout="this.style.borderColor='{{ card_border }}'">
+<div data-headline="{{ story.headline|e }}" data-summary="{{ story.summary|default('')|replace('\n',' ')|e }}" data-articles="{{ arts|tojson|e }}" data-image="{{ image|e }}" style="background:{{ card_bg }};border:1px solid {{ card_border }};border-radius:10px;padding:16px 18px;cursor:pointer;transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(255,255,255,0.15)'" onmouseout="this.style.borderColor='{{ card_border }}'">
   <div style="font-size:{{ hl_size }};line-height:1.5;color:#f0ece4;font-weight:400;margin-bottom:8px;">{% if is_top %}<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:{{ ac }};margin-right:8px;margin-bottom:1px;vertical-align:middle;"></span>{% endif %}{{ story.headline|e }}</div>
   <div style="font-size:11px;color:#555550;">{{ meta|e }}</div>
 </div>
 
 {% elif variant == 'yesterday_breaking' %}
-<div onclick="openModal({{ headline_js }},{{ summary_js }},{{ articles_js }},{{ image_js }})" style="background:#161614;border:1px solid rgba(255,255,255,0.05);border-radius:10px;padding:14px 16px;cursor:pointer;transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(255,255,255,0.15)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.05)'">
+<div data-headline="{{ story.headline|e }}" data-summary="{{ story.summary|default('')|replace('\n',' ')|e }}" data-articles="{{ arts|tojson|e }}" data-image="{{ image|e }}" style="background:#161614;border:1px solid rgba(255,255,255,0.05);border-radius:10px;padding:14px 16px;cursor:pointer;transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(255,255,255,0.15)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.05)'">
   <div style="font-size:12px;line-height:1.5;color:#c8c4bc;font-weight:400;margin-bottom:6px;">{{ story.headline|e }}</div>
   <div style="font-size:11px;color:#444440;">{{ story.timestamp|default('')|e }}</div>
 </div>
@@ -197,7 +197,7 @@ html,body{background:#111110;color:#f0ece4;font-family:'Inter',sans-serif;font-s
           <div style="font-size:14px;font-weight:500;color:#f0ece4;">{{ s.topic|e }}<span style="font-size:10px;padding:2px 8px;border-radius:999px;background:{{ badge_bg }};color:{{ badge_color }};margin-left:8px;vertical-align:middle;">{{ badge_text }}</span></div>
           <button onclick="removeSituation({{ s.topic|tojson }})" title="Stop tracking" style="background:none;border:none;cursor:pointer;color:#333330;font-size:16px;padding:0;line-height:1;transition:color 0.15s;" onmouseover="this.style.color='#c0392b'" onmouseout="this.style.color='#333330'">&#215;</button>
         </div>
-        <div style="font-size:13px;line-height:1.7;color:#8a8680;{% if not s.has_update %}font-style:italic;{% endif %}">{{ s.update|default('No updates today.')|e }}</div>
+        <div style="font-size:13px;line-height:1.7;color:#8a8680;{% if not s.has_update %}font-style:italic;{% endif %}">{{ s['update']|default('No updates today.')|e }}</div>
         {% if s.has_update and s.articles %}
         <div style="margin-top:10px;">
           {% for a in s.articles %}
@@ -417,7 +417,18 @@ function removeSituation(topic) {
   });
 }
 
-// ── Story modal ──
+// ── Story modal — delegated listener picks up data-* attrs ──
+document.addEventListener('click', function(e) {
+  var card = e.target.closest('.story, [data-headline]');
+  if (!card) return;
+  var headline = card.getAttribute('data-headline') || '';
+  var summary = card.getAttribute('data-summary') || '';
+  var image = card.getAttribute('data-image') || '';
+  var articles = [];
+  try { articles = JSON.parse(card.getAttribute('data-articles') || '[]'); } catch(ex) {}
+  openModal(headline, summary, articles, image);
+});
+
 function openModal(headline, summary, articles, image) {
   document.getElementById('modal-headline').textContent = headline;
   document.getElementById('modal-summary').textContent = summary;


### PR DESCRIPTION
## Summary
- **Bug 1 — Developing situations showing Python repr:** Jinja2 dot-notation `s.update` resolves to Python's built-in `dict.update()` method rather than the `'update'` key. Fixed in `page/template.html` — changed `s.update` → `s['update']` (bracket notation bypasses attribute lookup).
- **Bug 2 — Story modals not opening:** Inline `onclick="openModal({{ headline_js }}, ...)"` corrupts when summary/article JSON contains quotes, apostrophes, or newlines inside an HTML attribute. Replaced all three card variants (column, breaking, yesterday_breaking) with `data-headline/summary/articles/image` attributes and a single delegated `document` click listener.

## Changes
- `page/template.html` — data-attrs on all story card variants, delegated click listener, `s['update']` fix
- `STATUS.md` — Last Shipped updated

## Test plan
- [ ] Trigger a `deploy_only` run and open the briefing page
- [ ] Click any story card — modal opens with correct headline and summary
- [ ] Click a story with quotes or apostrophes in the summary — modal still opens
- [ ] Developing situations panel shows text summaries, not Python method reprs
- [ ] Star button still works (stopPropagation prevents modal firing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)