### PR TITLE
Autonomous bug hunt: fix GDELT error prefix, call_haiku crash, football source attribution

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Daily Briefing — Project Status
 
 ## Last Shipped
-Fixed breaking news article drop bug; cleared stale story cache to eliminate contaminated modal sources
+Fixed 3 bugs: malformed GDELT error prefix ("; RSS fallback also empty"), call_haiku crash on API failure, football source hardcoded as "The Guardian"
 
 ## 🔄 In Progress
 Nothing currently in progress.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Daily Briefing — Project Status
 
 ## Last Shipped
-Fixed 3 bugs: malformed GDELT error prefix ("; RSS fallback also empty"), call_haiku crash on API failure, football source hardcoded as "The Guardian"
+Autonomous bug hunt: fixed GDELT error prefix, call_haiku crash handling, football source attribution
 
 ## 🔄 In Progress
 Nothing currently in progress.

--- a/api.py
+++ b/api.py
@@ -95,14 +95,24 @@ def relative_time(date_str):
         return ""
 
 
-def call_haiku(prompt, max_tokens=500, label="haiku"):
-    msg = client.messages.create(
-        model="claude-haiku-4-5-20251001",
-        max_tokens=max_tokens,
-        messages=[{"role": "user", "content": prompt}]
-    )
-    log_api_call(label, msg.model, msg.usage.input_tokens, msg.usage.output_tokens)
-    return msg.content[0].text
+def call_haiku(prompt, max_tokens=500, label="haiku", retries=3):
+    for attempt in range(retries):
+        try:
+            msg = client.messages.create(
+                model="claude-haiku-4-5-20251001",
+                max_tokens=max_tokens,
+                messages=[{"role": "user", "content": prompt}]
+            )
+            log_api_call(label, msg.model, msg.usage.input_tokens, msg.usage.output_tokens)
+            return msg.content[0].text
+        except anthropic.RateLimitError:
+            wait = 20 * (attempt + 1)
+            print(f"Haiku rate limit, waiting {wait}s (attempt {attempt+1}/{retries})...")
+            time.sleep(wait)
+        except Exception as e:
+            print(f"Haiku error: {e}")
+            break
+    return ""
 
 
 def call_sonnet(prompt, max_tokens=1000, retries=3, label="sonnet"):

--- a/fetchers.py
+++ b/fetchers.py
@@ -121,7 +121,8 @@ def fetch_gdelt_articles(query, timespan="1h", max_records=25, memory=None):
         if articles:
             print(f"GDELT RSS fallback succeeded: {len(articles)} articles")
             return articles, "", memory
-        final_err = err + "; RSS fallback also empty"
+        prefix = err if err else "GDELT fetch failed: empty response"
+        final_err = prefix + "; RSS fallback also empty"
         print(f"GDELT RSS fallback: {rss_err}")
         return [], final_err, memory
     except Exception as e:

--- a/processors.py
+++ b/processors.py
@@ -321,7 +321,7 @@ Raw JSON only, no markdown."""
     for story in stories:
         time.sleep(3)
         orig = next((a for a in articles if a["url"] == story.get("url", "")), {})
-        articles_list = [{"title": orig.get("title", ""), "source": story.get("source", "The Guardian"), "url": story.get("url", "")}]
+        articles_list = [{"title": orig.get("title", ""), "source": orig.get("source", story.get("source", "")), "url": story.get("url", "")}]
         context = story.get("so_what", "")
         if context:
             cached_sources = find_related_cached_stories(memory, context)


### PR DESCRIPTION
## Summary

Three bugs found and fixed during an autonomous debug session. All were identified by reading health.json error patterns and cross-checking source code.

- **Malformed GDELT error prefix** — When GDELT JSON returns 200 with an empty article list, `err = ""`. The RSS fallback then built `final_err = "" + "; RSS fallback also empty"`, producing a leading `"; "` seen repeatedly in health.json. Fixed in `fetchers.py:124` by using `"GDELT fetch failed: empty response"` as the prefix when `err` is empty.

- **`call_haiku` crash on API failure** — `call_haiku` in `api.py:98` had zero exception handling. Any rate limit, network error, or model failure raised an unhandled exception that aborted the entire run, skipping HTML output. Affected `world_topics` and `developing_situations`. Fixed with the same retry pattern as `call_sonnet` — 3 attempts with 20s backoff, returns `""` on total failure.

- **Football source hardcoded as "The Guardian"** — `processors.py:324` used `story.get("source", "The Guardian")`, so articles from Marca, ESPN, Kicker, BBC Sport etc. all showed The Guardian as their source when the URL match failed. Fixed to `orig.get("source", story.get("source", ""))` — real source from fetched article first, Claude's response second, empty string fallback.

## Linked issues

Closes #38, #39, #40

## Test plan

- [ ] Confirm health.json errors no longer have a leading `"; "` prefix after a GDELT empty-response run
- [ ] Confirm a run completes successfully when Haiku hits a rate limit (retries rather than crashing)
- [ ] Confirm football article sources reflect the actual outlet (Marca, ESPN, etc.) rather than The Guardian